### PR TITLE
Fix click on last searched item

### DIFF
--- a/app/src/main/kotlin/de/ywegel/svenska/data/preferences/ArrayDequeSerializer.kt
+++ b/app/src/main/kotlin/de/ywegel/svenska/data/preferences/ArrayDequeSerializer.kt
@@ -1,0 +1,22 @@
+package de.ywegel.svenska.data.preferences
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+object ArrayDequeSerializer : KSerializer<ArrayDeque<String>> {
+    private val delegateSerializer = ListSerializer(String.serializer())
+
+    override val descriptor: SerialDescriptor = delegateSerializer.descriptor
+
+    override fun serialize(encoder: Encoder, value: ArrayDeque<String>) {
+        delegateSerializer.serialize(encoder, value.toList())
+    }
+
+    override fun deserialize(decoder: Decoder): ArrayDeque<String> {
+        return ArrayDeque(delegateSerializer.deserialize(decoder))
+    }
+}

--- a/app/src/main/kotlin/de/ywegel/svenska/data/preferences/LastSearchExtensions.kt
+++ b/app/src/main/kotlin/de/ywegel/svenska/data/preferences/LastSearchExtensions.kt
@@ -1,0 +1,11 @@
+package de.ywegel.svenska.data.preferences
+
+fun <T> ArrayDeque<T>.addToFrontAndLimit(item: T, limit: Int = LAST_SEARCHED_LIMIT) {
+    this.remove(item)
+    this.addFirst(item)
+    while (this.size > limit) {
+        this.removeLast()
+    }
+}
+
+private const val LAST_SEARCHED_LIMIT = 8

--- a/app/src/main/kotlin/de/ywegel/svenska/ui/search/SearchScreen.kt
+++ b/app/src/main/kotlin/de/ywegel/svenska/ui/search/SearchScreen.kt
@@ -126,6 +126,7 @@ private fun SearchScreen(
             vocabulary = vocabulary,
             searchQuery = currentSearchQuery,
             // onItemClicked = navigateToPopUp, TODO: Show a pop up view of the Item, if clicked
+            onRecentSearchedClicked = onSearchChanged,
             uiState = uiState,
             onOnlineRedirectClicked = { baseUrl, query ->
                 try {

--- a/app/src/main/kotlin/de/ywegel/svenska/ui/search/SearchScreen.kt
+++ b/app/src/main/kotlin/de/ywegel/svenska/ui/search/SearchScreen.kt
@@ -69,8 +69,6 @@ import de.ywegel.svenska.ui.theme.Spacings
 import de.ywegel.svenska.ui.theme.SvenskaIcons
 import de.ywegel.svenska.ui.theme.SvenskaTheme
 import kotlinx.coroutines.launch
-import java.util.LinkedList
-import java.util.Queue
 
 private const val TAG = "SearchScreen"
 
@@ -126,7 +124,7 @@ private fun SearchScreen(
             vocabulary = vocabulary,
             searchQuery = currentSearchQuery,
             // onItemClicked = navigateToPopUp, TODO: Show a pop up view of the Item, if clicked
-            onRecentSearchedClicked = onSearchChanged,
+            onRecentSearchedClicked = onSearch,
             uiState = uiState,
             onOnlineRedirectClicked = { baseUrl, query ->
                 try {
@@ -361,7 +359,7 @@ private fun SearchScreenPreviewEmpty() {
     SvenskaTheme {
         SearchScreen(
             uiState = SearchUiState(
-                lastSearchedItems = LinkedList(listOf("abc", "def", "ghi")) as Queue<String>,
+                lastSearchedItems = ArrayDeque(listOf("abc", "def", "ghi")),
             ),
             vocabulary = emptyList(),
             currentSearchQuery = "",
@@ -378,7 +376,7 @@ private fun SearchScreenPreviewFilled() {
     SvenskaTheme {
         SearchScreen(
             uiState = SearchUiState(
-                lastSearchedItems = LinkedList(emptyList<String>()) as Queue<String>,
+                lastSearchedItems = ArrayDeque(emptyList<String>()),
             ),
             vocabulary = emptyList(),
             currentSearchQuery = "abc",

--- a/app/src/main/kotlin/de/ywegel/svenska/ui/search/SearchViewModel.kt
+++ b/app/src/main/kotlin/de/ywegel/svenska/ui/search/SearchViewModel.kt
@@ -19,8 +19,6 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import java.util.LinkedList
-import java.util.Queue
 import javax.inject.Inject
 
 @HiltViewModel
@@ -72,18 +70,8 @@ class SearchViewModel @Inject constructor(
     fun onSearch(query: String) {
         _searchQuery.value = query
 
-        _uiState.update {
-            val updated = it.lastSearchedItems
-            if (updated.size == MAX_LAST_SEARCH_COUNT) {
-                updated.poll()
-            }
-            updated.add(query)
-            it.copy(lastSearchedItems = updated)
-        }
         viewModelScope.launch(ioDispatcher) {
-            userPreferencesManager.updateOverviewLastSearchedItems(
-                (_uiState.value.lastSearchedItems as LinkedList<String>),
-            )
+            userPreferencesManager.addLastSearchedItem(query)
         }
     }
 
@@ -103,10 +91,8 @@ class SearchViewModel @Inject constructor(
 }
 
 data class SearchUiState(
-    val lastSearchedItems: Queue<String> = LinkedList(),
+    val lastSearchedItems: ArrayDeque<String> = ArrayDeque(),
     val showCompactVocabularyItem: Boolean = false,
     val showOnlineRedirectFirst: Boolean = false,
     val onlineRedirectUrl: String? = null,
 )
-
-private const val MAX_LAST_SEARCH_COUNT = 5

--- a/app/src/test/kotlin/de/ywegel/svenska/data/preferences/ArrayDequeSerializerTest.kt
+++ b/app/src/test/kotlin/de/ywegel/svenska/data/preferences/ArrayDequeSerializerTest.kt
@@ -1,0 +1,35 @@
+package de.ywegel.svenska.data.preferences
+
+import de.ywegel.svenska.jsonConfig
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ArrayDequeSerializerTest {
+
+    @Test
+    fun `serialization roundtrip preserves ArrayDeque`() {
+        val original = ArrayDeque(listOf("a", "b", "c"))
+        val json = jsonConfig.encodeToString(ArrayDequeSerializer, original)
+        val decoded = jsonConfig.decodeFromString(ArrayDequeSerializer, json)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun `empty ArrayDeque serializes and deserializes correctly`() {
+        val original = ArrayDeque<String>()
+        val json = jsonConfig.encodeToString(ArrayDequeSerializer, original)
+        val decoded = jsonConfig.decodeFromString(ArrayDequeSerializer, json)
+        assertTrue(decoded.isEmpty())
+    }
+
+    @Test
+    fun `order of elements is preserved`() {
+        val deque = ArrayDeque(listOf("first", "second", "third"))
+        val result = jsonConfig.decodeFromString(
+            ArrayDequeSerializer,
+            jsonConfig.encodeToString(ArrayDequeSerializer, deque),
+        )
+        assertEquals(listOf("first", "second", "third"), result.toList())
+    }
+}

--- a/app/src/test/kotlin/de/ywegel/svenska/data/preferences/LastSearchExtensionsTest.kt
+++ b/app/src/test/kotlin/de/ywegel/svenska/data/preferences/LastSearchExtensionsTest.kt
@@ -1,0 +1,43 @@
+package de.ywegel.svenska.data.preferences
+
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.containsExactly
+
+class LastSearchExtensionsTest {
+
+    @Test
+    fun `adds new element to empty deque`() {
+        val deque = ArrayDeque<String>()
+        deque.addToFrontAndLimit("a", 3)
+        expectThat(deque.toList()).containsExactly("a")
+    }
+
+    @Test
+    fun `adds new element to front if not present`() {
+        val deque = ArrayDeque(listOf("b", "c"))
+        deque.addToFrontAndLimit("a", 3)
+        expectThat(deque.toList()).containsExactly(listOf("a", "b", "c"))
+    }
+
+    @Test
+    fun `moves existing element to front`() {
+        val deque = ArrayDeque(listOf("a", "b"))
+        deque.addToFrontAndLimit("b", 3)
+        expectThat(deque.toList()).containsExactly(listOf("b", "a"))
+    }
+
+    @Test
+    fun `removes oldest element when limit exceeded`() {
+        val deque = ArrayDeque(listOf("a", "b", "c"))
+        deque.addToFrontAndLimit("d", 3)
+        expectThat(deque.toList()).containsExactly(listOf("d", "a", "b"))
+    }
+
+    @Test
+    fun `existing element moved to front without exceeding limit`() {
+        val deque = ArrayDeque(listOf("a", "b", "c"))
+        deque.addToFrontAndLimit("b", 3)
+        expectThat(deque.toList()).containsExactly(listOf("b", "a", "c"))
+    }
+}

--- a/app/src/test/kotlin/de/ywegel/svenska/fakes/UserPreferencesManagerFake.kt
+++ b/app/src/test/kotlin/de/ywegel/svenska/fakes/UserPreferencesManagerFake.kt
@@ -5,13 +5,12 @@ import de.ywegel.svenska.data.preferences.AppPreferences
 import de.ywegel.svenska.data.preferences.OverviewPreferences
 import de.ywegel.svenska.data.preferences.SearchPreferences
 import de.ywegel.svenska.data.preferences.UserPreferencesManager
+import de.ywegel.svenska.data.preferences.addToFrontAndLimit
 import de.ywegel.svenska.domain.search.OnlineSearchType
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
-import java.util.LinkedList
-import java.util.Queue
 
 class UserPreferencesManagerFake(
     initialSortOrder: SortOrder = SortOrder.default,
@@ -48,7 +47,7 @@ class UserPreferencesManagerFake(
     }
 
     private val currentSearchPreferences = SearchPreferences(
-        lastSearchedItems = LinkedList(),
+        lastSearchedItems = ArrayDeque(),
         showOnlineRedirectFirst = false,
         showCompactVocabularyItem = false,
         onlineRedirectType = OnlineSearchType.DictCC,
@@ -58,9 +57,11 @@ class UserPreferencesManagerFake(
 
     override val preferencesSearchFlow: Flow<SearchPreferences> = _preferencesSearchFlow.asStateFlow()
 
-    override suspend fun updateOverviewLastSearchedItems(queue: Queue<String>) {
+    override suspend fun addLastSearchedItem(item: String) {
         _preferencesSearchFlow.update {
-            it.copy(lastSearchedItems = queue)
+            val copiedQueue = ArrayDeque(it.lastSearchedItems)
+            copiedQueue.addToFrontAndLimit(item)
+            it.copy(lastSearchedItems = copiedQueue)
         }
     }
 


### PR DESCRIPTION
Users can now click on last searched items to search for them again. The logic has been adjusted as well