### PR TITLE
Fixed: Migrations crashing on api level 33 and lower

### DIFF
--- a/app/src/main/kotlin/de/ywegel/svenska/data/db/Migrations.kt
+++ b/app/src/main/kotlin/de/ywegel/svenska/data/db/Migrations.kt
@@ -10,42 +10,41 @@ val MIGRATION_1_2 = object : Migration(1, 2) {
     override fun migrate(db: SupportSQLiteDatabase) {
         Log.i(TAG, "migrate: Starting migration from 1 to 2...")
 
-        // Create temporary column
-        db.execSQL("ALTER TABLE Vocabulary ADD COLUMN temp_wordHighlights TEXT NOT NULL DEFAULT ''")
+        db.beginTransaction()
+        try {
+            // Convert each highlight to the new pair format
+            val cursor = db.query("SELECT id, wordHighlights, word FROM Vocabulary")
 
-        // Convert each highlight to the new pair format
-        val cursor = db.query("SELECT id, wordHighlights, word FROM Vocabulary")
-        while (cursor.moveToNext()) {
-            val id = cursor.getInt(0)
-            val oldHighlightsStr = cursor.getString(1) // Old format: "1;3;5;7;8"
-            val word = cursor.getString(2)
+            while (cursor.moveToNext()) {
+                val id = cursor.getInt(0)
+                val oldHighlightsStr = cursor.getString(1) // Old format: "1;3;5;7;8"
+                val word = cursor.getString(2)
 
-            val newHighlightsStr = if (oldHighlightsStr.isNotEmpty()) {
-                oldHighlightsStr.split(";")
-                    .mapNotNull { it.trim().toIntOrNull() } // Drop invalid highlights
-                    .chunked(2)
-                    .filter { it.size == 2 }
-                    .filter { (first, second) ->
-                        // Filter out negative and out of bounds highlights
-                        first >= 0 && second >= 0 && first <= word.length && second <= word.length
-                    }
-                    .joinToString(",") { (first, second) -> "$first:$second" } // New format: "1:3,5:7"
-            } else {
-                ""
+                val newHighlightsStr = if (oldHighlightsStr.isNotEmpty()) {
+                    oldHighlightsStr.split(";")
+                        .mapNotNull { it.trim().toIntOrNull() } // Drop invalid highlights
+                        .chunked(2)
+                        .filter { it.size == 2 }
+                        .filter { (first, second) ->
+                            // Filter out negative and out of bounds highlights
+                            first >= 0 && second >= 0 && first <= word.length && second <= word.length
+                        }
+                        .joinToString(",") { (first, second) -> "$first:$second" } // New format: "1:3,5:7"
+                } else {
+                    ""
+                }
+
+                // Update the temp column with new format
+                db.execSQL(
+                    sql = "UPDATE Vocabulary SET wordHighlights = ? WHERE id = ?",
+                    bindArgs = arrayOf<Any>(newHighlightsStr, id),
+                )
             }
-
-            // Update the temp column with new format
-            db.execSQL(
-                sql = "UPDATE Vocabulary SET temp_wordHighlights = ? WHERE id = ?",
-                bindArgs = arrayOf<Any>(newHighlightsStr, id),
-            )
+            cursor.close()
+            db.setTransactionSuccessful()
+        } finally {
+            db.endTransaction()
+            Log.i(TAG, "migrate: Migration from 1 to 2 finished")
         }
-        cursor.close()
-
-        // Drop the old column and rename temp_wordHighlights to wordHighlights
-        db.execSQL("ALTER TABLE Vocabulary DROP COLUMN wordHighlights")
-        db.execSQL("ALTER TABLE Vocabulary RENAME COLUMN temp_wordHighlights TO wordHighlights")
-
-        Log.i(TAG, "migrate: Migration from 1 to 2 finished")
     }
 }


### PR DESCRIPTION
The migrations are crashing on api level 33 and lower, because the "Rename" keyword is only available in sqlite 3.35 and higher. This sqlite version is only available at api level 34 and higher, see https://developer.android.com/reference/android/database/sqlite/package-summary

This is fixed by migrating in place, instead of creating a temporary column. 